### PR TITLE
Use newer versions of AFNetworking and JWT

### DIFF
--- a/LFSClient/Classes/LFSJSONResponseSerializer.h
+++ b/LFSClient/Classes/LFSJSONResponseSerializer.h
@@ -7,7 +7,7 @@
 //
 
 #import "LFSBaseClient.h"
-#import "AFURLResponseSerialization.h"
+#import <AFNetworking/AFURLResponseSerialization.h>
 
 @interface LFSJSONResponseSerializer : AFHTTPResponseSerializer
 

--- a/LFSClient/Classes/LFSTextResponseSerializer.h
+++ b/LFSClient/Classes/LFSTextResponseSerializer.h
@@ -7,7 +7,7 @@
 //
 
 #import "LFSBaseClient.h"
-#import "AFURLResponseSerialization.h"
+#import <AFNetworking/AFURLResponseSerialization.h>
 
 @interface LFSTextResponseSerializer: AFHTTPResponseSerializer
 /**

--- a/StreamHub-iOS-SDK.podspec
+++ b/StreamHub-iOS-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "StreamHub-iOS-SDK"
-  s.version      = "0.3.8"
+  s.version      = "0.3.9"
   s.summary      = "A client library for Livefyre's API"
   s.description  = <<-DESC
 StreamHub-iOS is the official Livefyre SDK for building real-time native iOS apps that interact with Livefyre services. With it, you can easily create apps that obtain user-generated content sourced by Livefye, poll for updates, and create or modify content.
@@ -16,8 +16,8 @@ StreamHub-iOS is the official Livefyre SDK for building real-time native iOS app
   s.subspec 'core' do |sp|
     sp.source_files = 'LFSClient/**/*.{h,m}'
     sp.requires_arc = true
-    sp.dependency 'AFNetworking', '2.3.1'
-    sp.dependency 'JWT', '1.0.3'
+    sp.dependency 'AFNetworking', '2.6.3'
+    sp.dependency 'JWT', '1.1.0'
     sp.dependency 'Base64', '1.0.1'
     sp.dependency 'NSString-Hashes', '1.2.2'
   end


### PR DESCRIPTION
This makes StreamHub compatible with `use_frameworks` in cocoapods. Fixes https://github.com/Livefyre/StreamHub-iOS-SDK/issues/76